### PR TITLE
Add project to SumUp's Service Catalog

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,1 +1,0 @@
-Hello World!

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -24,7 +24,7 @@ metadata:
   links: 
     # Homepage taken from repository website setting, optional
     - title: Homepage
-      url: https://github.com/robinbraemer/test-create-pr 
+      url: https://example.com 
     # Link to Alerts Runbook, required
     #- title: Alerts Runbook
     #  url: https://sumupteam.atlassian.net/wiki/spaces/DEV/pages/2517664574/Ecom+Platform+Squad+Runbook

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,79 @@
+# Catalog Service template
+# Please follow all comments to update values.
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  # Name of the service, required
+  name: test-create-pr
+  # Human readable version of the name of the service, required
+  title: Test Create Pr
+  # Short and crisp description of the service, required
+  description: Demo repo to test creating pull requests entirely via GitHub API
+  annotations:
+    # Slug of the GitHub repo, required
+    github.com/project-slug: robinbraemer/test-create-pr
+    # Location of the mkdocs.yml file, optional
+    backstage.io/techdocs-ref: dir:./docs
+  # Tags that identify the service by characteristics, required:
+  # - pii, if service deals with personal identifiable information)
+  # - pci, if service is located in the PCI zone (deals with payments related data)
+  # - critical-path, if service needs immediate response in case of incident
+  # - externally-exposed, if API is reachable through wwww
+  # Example: [critical-path, pii]
+  tags: [ sumup, testing ] 
+  links: 
+    # Homepage taken from repository website setting, optional
+    - title: Homepage
+      url: https://github.com/robinbraemer/test-create-pr 
+    # Link to Alerts Runbook, required
+    #- title: Alerts Runbook
+    #  url: https://sumupteam.atlassian.net/wiki/spaces/DEV/pages/2517664574/Ecom+Platform+Squad+Runbook
+    # Link to Confluence Team page, optional
+    #- title: Confluence Page
+    #  url: https://sumupteam.atlassian.net/wiki/spaces/DEV/pages/554239270/Ecom+Platform+Squad
+    # Link to Slack channel for service alerts, required
+    #- title: Slack Alert Channel
+    #  url: https://sumup.slack.com/archives/CC1GHFV3P
+    # Link to Slack support channel for service (e.g. team/squad channel), required
+    #- title: Slack Support Channel
+    #  url: https://sumup.slack.com/archives/CC1GHFV3P
+    # Link to Grafana dashboards, recommended
+    #- title: Grafana
+    #  url: https://grafana.sam-app.ro/dashboards/f/yN_aXbBGz/ecom-platform
+    #  type: telemetry
+    # Link to Honeycomb dashboards, recommended
+    #- title: Honeycomb
+    #  url: https://ui.honeycomb.io/sumup/board/A3ThTUE4rXf/Ecom-Platform
+    #  type: telemetry
+spec:
+  # Defines the type of Component (service, website, library, see https://backstage.io/docs/features/software-catalog/descriptor-format#spectype-required), required
+  type: unspecified
+  # Marks the state of the service (production, experimental, deprecated, see https://backstage.io/docs/features/software-catalog/descriptor-format#speclifecycle-required), required
+  lifecycle: unspecified
+  # GitHub team owner, see https://github.com/orgs/sumup/teams, required
+  owner: unspecified
+  # List of API's the service exposes, reference name from the API definition section below, required
+  # If adding the API's is a blocker, slack #backstage to get our help
+  providesApis: [ ]
+  # List of API's the service is connected to, see openapi or https://sumup.roadie.so/api-docs, required
+  consumesApis: [ ]
+---
+# API definition example
+#apiVersion: backstage.io/v1alpha1
+#kind: API
+#metadata:
+#  name: test-create-pr-api
+#  title: Test Create Pr API
+#  # add [externally-exposed] if API is reachable through wwww, required if applicable
+#  tags: [ sumup, testing ] 
+#  # API description, required
+#  description: |
+#    Sample API description.
+#spec:
+#  type: openapi
+#  # Marks the state of the API (production, experimental, deprecated, see https://backstage.io/docs/features/software-catalog/descriptor-format#speclifecycle-required), required
+#  lifecycle: unspecified
+#  # Github team owner, see https://github.com/orgs/sumup/teams, required
+#  owner: unspecified
+#  definition:
+#    $text: https://github.com/sumup/ecom-platform/blob/master/apps/vatcalculator/docs/index.yaml

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -52,12 +52,14 @@ spec:
   lifecycle: unspecified
   # GitHub team owner, see https://github.com/orgs/sumup/teams, required
   owner: unspecified
+  # The system this Component is part of, recommended
+  system: unspecified
   # List of API's the service exposes, reference name from the API definition section below, required
   # If adding the API's is a blocker, slack #backstage to get our help
   providesApis: [ ]
   # List of API's the service is connected to, see openapi or https://sumup.roadie.so/api-docs, required
   consumesApis: [ ]
----
+#---
 # API definition example
 #apiVersion: backstage.io/v1alpha1
 #kind: API

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,1 @@
+Hello World!


### PR DESCRIPTION
## This automated PR adds the project to the [SumUp Service Catalog](https://sumup.roadie.so/catalog?filters%5Bkind%5D=component&filters%5Buser%5D=all)

> It was created by the [Backstage Catalogify Rollout CLI](https://github.com/sumup/backstage-catalogify).

![image](https://user-images.githubusercontent.com/22003767/199686773-2cdf3068-02e5-4d7c-a2d8-1a24d60e86d0.png)

Good news regarding our SumUp Service Catalog, one of the initiatives of our [99.99% Reliability efforts](https://docs.google.com/presentation/d/1ZU07c4qqO1svVaE47dcT7cO2lS47Qdm9ObQ0rEClav8/edit#slide=id.g148f9afe725_2_18) (see strategy map[ here](https://miro.com/app/board/uXjVO6L1bxo=/?moveToWidget=3458764533280006805&cot=14))! Like in many other companies, the Service Catalog will help us to organize API documentation, ownership of services, PII tagging, Dependabot alerts, and many other benefits that require a professional inventory.

> Per [Backstage use cases](https://backstage.io/docs/features/software-catalog/software-catalog-overview#how-it-works) and [Roadie's recommendation](https://sumup.slack.com/archives/C03V12MRD7A/p1662975548377709?thread_ts=1662734521.151619&cid=C03V12MRD7A), we curate more than just projects in the catalog, but also libraries, internal/external APIs, documentation, and other company resources represented by GitHub repositories, teams and various other domain entities at SumUp.

## What's included
  
This auto-generated PR includes a boilerplate `catalog-info.yaml`,
a Backstage Service Catalog Component entry for this project filled out with the bare minimum.

## Please merge first

By merging this PR, your repository will automatically be added to [SumUp's Service Catalog](https://sumup.roadie.so/catalog?filters%5Bkind%5D=component&filters%5Buser%5D=all).

Please merge this PR first, and when you find time, adapt the `catalog-info.yaml` to contain meaningful data. You will find a tutorial, FAQs, and other docs [here](https://sumupteam.atlassian.net/wiki/spaces/DEV/pages/22050275741/Service+Catalog).

## Our motivations for this PR approach

- By auto-generating the PRs, we minimize chore work by repo owners
- By [automatically tracking](https://docs.google.com/spreadsheets/d/1xer-AbUXpNEaxb0IysAt_W24f1onK4LuDP5t39YOGX4/edit#gid=0) unmerged `catalog-info.yaml` PRs, we identify repositories without owner
- We want all resources in the catalog as early as possible, with minimum effort for the squads. The catalog is our tool of choice for tracking the state of our services/resources. Backstage is the future-proof successor of OpsLevel. By filtering resources by `unspecified` values, we know which repositories still need work and ownership.

### Some known issues are:

- During mass adoption the auto-generating PRs will instrument loads of repositories that shouldn't be in the catalog (abandoned-but-not-yet-archived, one-time script collections, etc.) -> We won't merge these PRs so that they won't show up in the catalog.

## Support

If you have questions about the Service Catalog or SumUp's Internal Developer Portal in general,
we are happy to support you in our [Slack channel #backstage](https://sumup.slack.com/archives/C03DLS08PRD)!

There is also an external support channel offered by our Backstage provider at [#roadie-sumup](https://sumup.slack.com/archives/C03V12MRD7A).
